### PR TITLE
chore: Add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ knapsack-dist
 yarn-error.log
 .env
 .DS_Store
+.envrc


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-cloud/public-demo-design-tokens@0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0
  npm install @knapsack-cloud/public-demo-react@0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0
  npm install @knapsack-cloud/public-demo-styles@0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0
  npm install @knapsack-cloud/public-demo-web-components@0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0
  # or 
  yarn add @knapsack-cloud/public-demo-design-tokens@0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0
  yarn add @knapsack-cloud/public-demo-react@0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0
  yarn add @knapsack-cloud/public-demo-styles@0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0
  yarn add @knapsack-cloud/public-demo-web-components@0.1.61--canary.221.c24b46f88ce7943af065eecca89c3f1ad41d31f0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
