### PR TITLE
Add typography theming

### DIFF
--- a/data/knapsack.asset-sets.json
+++ b/data/knapsack.asset-sets.json
@@ -9,10 +9,10 @@
           "src": "../packages/design-tokens/dist/design-tokens.css"
         },
         {
-          "src": "../packages/styles/dist/styles.css"
+          "src": "../packages/styles/dist/default.css"
         },
         {
-          "src": "../packages/styles/dist/default.css"
+          "src": "../packages/styles/dist/styles.css"
         },
         {
           "src": "../packages/web-components/dist/index.js",

--- a/data/knapsack.design-tokens.json
+++ b/data/knapsack.design-tokens.json
@@ -388,5 +388,15 @@
         }
       }
     }
+  },
+  "Typography": {
+    "bodyFontFamily": {
+      "$value": "Pacifico",
+      "$type": "string"
+    },
+    "bodyFontUrl": {
+      "$value": "'https://fonts.gstatic.com/s/pacifico/v17/FwZY7-Qmy14u9lezJ-6J6MmBp0u-.woff2'",
+      "$type": "string"
+    }
   }
 }

--- a/packages/styles/src/default.css
+++ b/packages/styles/src/default.css
@@ -1,1 +1,16 @@
-@import url('https://rsms.me/inter/inter.css');
+@import url('https://fonts.googleapis.com/css2?family=Pacifico&display=swap');
+
+/* :root {
+  --typography-body-font-url: 'https://fonts.gstatic.com/s/pacifico/v17/FwZY7-Qmy14u9lezJ-6J6MmBp0u-.woff2';
+}
+
+@font-face {
+  font-family: 'Pacifico';
+  src: url(var(--typography-body-font-url)), format('woff2');
+  font-weight: 400;
+  font-style: normal;
+}
+
+body {
+  font-family: 'Pacifico', cursive;
+} */

--- a/packages/styles/tailwind.config.js
+++ b/packages/styles/tailwind.config.js
@@ -24,12 +24,15 @@ module.exports = {
       colors: {
         ...color,
         primary: 'var(--color-primary)',
-        secondary: 'var(--color-secondary)'
+        secondary: 'var(--color-secondary)',
       },
       screens: breakpoint.width,
       spacing,
       fontFamily: {
-        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+        sans: [
+          'var(--typography-body-font-family)',
+          ...defaultTheme.fontFamily.sans,
+        ],
       },
     },
   },


### PR DESCRIPTION
* fix: fix font import in default.css
* chore: update tailwind.config.js to use custom body font
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-cloud/public-demo-design-tokens@0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0
  npm install @knapsack-cloud/public-demo-react@0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0
  npm install @knapsack-cloud/public-demo-styles@0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0
  npm install @knapsack-cloud/public-demo-web-components@0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0
  # or 
  yarn add @knapsack-cloud/public-demo-design-tokens@0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0
  yarn add @knapsack-cloud/public-demo-react@0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0
  yarn add @knapsack-cloud/public-demo-styles@0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0
  yarn add @knapsack-cloud/public-demo-web-components@0.1.69--canary.255.49c37f7f0a34ececdb609c321460c9aace4a7058.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
