### PR TITLE
Trigger Dependabot Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,4 @@ updates:
     group:
       name: "knapsack-dependencies"
       description: "Group updates for Knapsack dependencies"
-    reviewers:
-      - "brittanysmart"
     target-branch: "main"

--- a/.github/workflows/label-dependabot.yml
+++ b/.github/workflows/label-dependabot.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Check if PR is from Dependabot
         id: check_dependabot
         run: |
-          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+          echo "Actor: ${{ github.actor }}"
+          if [[ "${{ github.actor }}" == *"dependabot"* ]]; then
             echo "is_dependabot=true" >> $GITHUB_ENV
           else
             echo "is_dependabot=false" >> $GITHUB_ENV


### PR DESCRIPTION
* chore(dependabot.yml): remove reviewer from knapsack-dependencies group

* fix(label-dependabot.yml): update condition to check if PR is from Dependabot
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-cloud/public-demo-design-tokens@0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0
  npm install @knapsack-cloud/public-demo-react@0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0
  npm install @knapsack-cloud/public-demo-styles@0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0
  npm install @knapsack-cloud/public-demo-web-components@0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0
  # or 
  yarn add @knapsack-cloud/public-demo-design-tokens@0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0
  yarn add @knapsack-cloud/public-demo-react@0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0
  yarn add @knapsack-cloud/public-demo-styles@0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0
  yarn add @knapsack-cloud/public-demo-web-components@0.1.73--canary.293.a7b7ca51949283c6a09d6d4e8dd4ae66269a22d8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
