### PR TITLE
Fix dependency names in allow and groups sections

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,24 @@ updates:
     schedule:
       interval: "daily"
     allow:
-      - dependency-name: "@knapsack/*"
+      - dependency-name: "@knapsack/app"
+      - dependency-name: "@knapsack/babel-config"
+      - dependency-name: "@knapsack/core"
+      - dependency-name: "@knapsack/design-token-utils"
+      - dependency-name: "@knapsack/plugin-changelog-md"
+      - dependency-name: "@knapsack/renderer-html"
+      - dependency-name: "@knapsack/renderer-react"
+      - dependency-name: "@knapsack/renderer-web-components"
     groups:
       knapsack-packages:
         patterns:
-          - "@knapsack/*"
+          - "@knapsack/app"
+          - "@knapsack/babel-config"
+          - "@knapsack/core"
+          - "@knapsack/design-token-utils"
+          - "@knapsack/plugin-changelog-md"
+          - "@knapsack/renderer-html"
+          - "@knapsack/renderer-react"
+          - "@knapsack/renderer-web-components"
     commit-message:
       prefix: "deps"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-cloud/public-demo-design-tokens@0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0
  npm install @knapsack-cloud/public-demo-react@0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0
  npm install @knapsack-cloud/public-demo-styles@0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0
  npm install @knapsack-cloud/public-demo-web-components@0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0
  # or 
  yarn add @knapsack-cloud/public-demo-design-tokens@0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0
  yarn add @knapsack-cloud/public-demo-react@0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0
  yarn add @knapsack-cloud/public-demo-styles@0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0
  yarn add @knapsack-cloud/public-demo-web-components@0.1.76--canary.308.8cc68e7b14f0172e2f0ae2147c7c4e3c9ca77eea.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
