### PR TITLE
Fix Dependabot PR builds by enforcing fresh dependency installs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,9 +32,6 @@ jobs:
         run: |
           yarn install --cache-folder ~/.cache/yarn --prefer-offline --frozen-lockfile
 
-      - name: Debug Build Directory
-        run: ls -R ./packages/react/dist
-
       - name: Run Full Build
         run: yarn build
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,9 +29,11 @@ jobs:
           key: node-deps-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           yarn install --cache-folder ~/.cache/yarn --prefer-offline --frozen-lockfile
+
+      - name: Debug Build Directory
+        run: ls -R ./packages/react/dist
 
       - name: Run Full Build
         run: yarn build


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-cloud/public-demo-design-tokens@0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0
  npm install @knapsack-cloud/public-demo-react@0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0
  npm install @knapsack-cloud/public-demo-styles@0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0
  npm install @knapsack-cloud/public-demo-web-components@0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0
  # or 
  yarn add @knapsack-cloud/public-demo-design-tokens@0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0
  yarn add @knapsack-cloud/public-demo-react@0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0
  yarn add @knapsack-cloud/public-demo-styles@0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0
  yarn add @knapsack-cloud/public-demo-web-components@0.1.77--canary.310.4fdda6afbb80859a3e51e147cf1239c1b1a1f486.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
