### PR TITLE
Add condition to skip release step for dependabot

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,6 +42,7 @@ jobs:
         run: yarn test
 
       - name: Release
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: yarn auto shipit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-cloud/public-demo-design-tokens@0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0
  npm install @knapsack-cloud/public-demo-react@0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0
  npm install @knapsack-cloud/public-demo-styles@0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0
  npm install @knapsack-cloud/public-demo-web-components@0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0
  # or 
  yarn add @knapsack-cloud/public-demo-design-tokens@0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0
  yarn add @knapsack-cloud/public-demo-react@0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0
  yarn add @knapsack-cloud/public-demo-styles@0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0
  yarn add @knapsack-cloud/public-demo-web-components@0.1.80--canary.313.6b311559dbeecaab28ba32e95fe8cc61a9f3aaaf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
