### PR TITLE
Update Dependabot to run weekly and allow updates for all @knapsack/* dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     allow:
-      - dependency-name: "@knapsack/app"
-      - dependency-name: "@knapsack/babel-config"
-      - dependency-name: "@knapsack/core"
-      - dependency-name: "@knapsack/design-token-utils"
-      - dependency-name: "@knapsack/plugin-changelog-md"
-      - dependency-name: "@knapsack/renderer-html"
-      - dependency-name: "@knapsack/renderer-react"
-      - dependency-name: "@knapsack/renderer-web-components"
+      - dependency-name: "@knapsack/*"
     groups:
       knapsack-packages:
         patterns:


### PR DESCRIPTION
- chore(dependabot.yml): update dependabot configuration to run weekly instead of daily
- chore(dependabot.yml): allow updates for all @knapsack/* dependencies
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @knapsack-cloud/public-demo-design-tokens@0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0
  npm install @knapsack-cloud/public-demo-react@0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0
  npm install @knapsack-cloud/public-demo-styles@0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0
  npm install @knapsack-cloud/public-demo-web-components@0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0
  # or 
  yarn add @knapsack-cloud/public-demo-design-tokens@0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0
  yarn add @knapsack-cloud/public-demo-react@0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0
  yarn add @knapsack-cloud/public-demo-styles@0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0
  yarn add @knapsack-cloud/public-demo-web-components@0.1.81--canary.314.57a79c5b697cb6bf9ce0d7d50964e7b9cf588b8e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
