### PR TITLE
Upgrade to heroku-22 stack and pin Node.js version to 18.20.5

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,14 @@
 {
+  "stack": "heroku-22",
   "buildpacks": [
     {
       "url": "heroku/nodejs"
     }
-  ]
+  ],
+  "env": {
+    "NODE_VERSION": {
+      "description": "Node.js version",
+      "value": "18.20.5"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "webpack-cli": "^3.3.11"
   },
   "engines": {
-    "node": "18.x"
+    "node": "18.20.5"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
# Stack Upgrade

This PR prepares the application for upgrading from heroku-20 to heroku-22 stack.

## Changes
- Set stack to heroku-22 in app.json
- Pin Node.js version to 18.20.5 for consistency across environments
- Update buildpack configuration for heroku-22 compatibility

## Testing
- Review App will be created with heroku-22 stack
- Verify application builds and runs correctly
- Confirm all functionality works as expected

## Notes
- Heroku-20 EOL is April 30th, 2024
- This upgrade ensures continued security updates and compatibility

## Rollback Plan
If issues occur:
1. Revert to heroku-20 stack
2. Return to previous Node.js version configuration
